### PR TITLE
patch: ajusta pipeline de ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,23 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - pre-release
+
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
@@ -17,16 +26,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --maxfail=5 --disable-warnings --cov=ingestion --cov-report=xml --junitxml=test-results.xml
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: test-results.xml
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: coverage.xml
+          pytest --maxfail=5 --disable-warnings


### PR DESCRIPTION
## Summary by Sourcery

Update the CI pipeline to run tests on pull requests against the main and pre-release branches, using Python 3.9.

CI:
- Run tests on pull requests to main and pre-release branches.
- Use Python 3.9 for running tests.

Tests:
- Remove test result and coverage report uploads.